### PR TITLE
Fix issue that results in 'val' keys added to objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,6 +226,7 @@ DecodingTransformer.prototype._handleCircularSelfRefDuringTransform = function (
 
         set: function (value) {
             val = value;
+            return val;
         }
     });
 };

--- a/index.js
+++ b/index.js
@@ -211,21 +211,21 @@ DecodingTransformer.prototype._handleCircularSelfRefDuringTransform = function (
     // new circular references. As a workaround we create getter, so once transformation
     // complete, dereferenced property will point to correct transformed object.
     var references = this.references;
+    var val = void 0;
 
     Object.defineProperty(parent, key, {
-        val:          void 0,
         configurable: true,
         enumerable:   true,
 
         get: function () {
-            if (this.val === void 0)
-                this.val = references[refIdx];
+            if (val === void 0)
+                val = references[refIdx];
 
-            return this.val;
+            return val;
         },
 
         set: function (value) {
-            this.val = value;
+            val = value;
         }
     });
 };


### PR DESCRIPTION
I have a pretty complicated serialization graph, and I've found that sometimes objects end up with random 'val' keys attached that seem to duplicate the value of another key. The change below fixes that - I'm pretty sure `this` in the handlers is inadvertently referencing `parent`.

I haven't found a simple repro case yet.