### PR TITLE
Avoid usage of eval() to comply with strict CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <i>Advanced JavaScript objects serialization</i>
 </p>
 <p align="center">
-  <a href="https://travis-ci.org/inikulin/replicator"><img alt="Build Status" src="https://api.travis-ci.org/inikulin/replicator.svg"></a>
+  <a href="https://github.com/inikulin/replicator/commits/master"><img alt="GitHub branch checks state" src="https://img.shields.io/github/checks-status/inikulin/replicator/master?label=tests"></a>
   <a href="https://www.npmjs.com/package/replicator"><img alt="NPM Version" src="https://img.shields.io/npm/v/replicator.svg"></a>
 </p>
 

--- a/index.js
+++ b/index.js
@@ -29,23 +29,26 @@ var GLOBAL = (function getGlobal () {
     /* eslint-enable */
 })();
 
+var TYPED_ARRAY_CTORS = {
+    'Int8Array':         typeof Int8Array === 'function' ? Int8Array : void 0,
+    'Uint8Array':        typeof Uint8Array === 'function' ? Uint8Array : void 0,
+    'Uint8ClampedArray': typeof Uint8ClampedArray === 'function' ? Uint8ClampedArray : void 0,
+    'Int16Array':        typeof Int16Array === 'function' ? Int16Array : void 0,
+    'Uint16Array':       typeof Uint16Array === 'function' ? Uint16Array : void 0,
+    'Int32Array':        typeof Int32Array === 'function' ? Int32Array : void 0,
+    'Uint32Array':       typeof Uint32Array === 'function' ? Uint32Array : void 0,
+    'Float32Array':      typeof Float32Array === 'function' ? Float32Array : void 0,
+    'Float64Array':      typeof Float64Array === 'function' ? Float64Array : void 0
+};
 
 var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';
 var MAP_SUPPORTED          = typeof Map === 'function';
 var SET_SUPPORTED          = typeof Set === 'function';
+var BUFFER_FROM_SUPPORTED  = typeof Buffer === 'function';
 
-var TYPED_ARRAY_CTORS = [
-    'Int8Array',
-    'Uint8Array',
-    'Uint8ClampedArray',
-    'Int16Array',
-    'Uint16Array',
-    'Int32Array',
-    'Uint32Array',
-    'Float32Array',
-    'Float64Array'
-];
-
+var TYPED_ARRAY_SUPPORTED  = function (typeName) {
+    return !!TYPED_ARRAY_CTORS[typeName];
+};
 
 // Saved proto functions
 var arrSlice = Array.prototype.slice;
@@ -427,17 +430,31 @@ var builtInTransforms = [
     },
 
     {
+        type: '[[Buffer]]',
+
+        shouldTransform: function (type, val) {
+            return BUFFER_FROM_SUPPORTED && val instanceof Buffer;
+        },
+
+        toSerializable: function (buffer) {
+            return arrSlice.call(buffer);
+        },
+
+        fromSerializable: function (val) {
+            if (BUFFER_FROM_SUPPORTED)
+                return Buffer.from(val);
+
+            return val;
+        }
+    },
+
+    {
         type: '[[TypedArray]]',
 
         shouldTransform: function (type, val) {
-            for (var i = 0; i < TYPED_ARRAY_CTORS.length; i++) {
-                var ctorName = TYPED_ARRAY_CTORS[i];
-
-                if (typeof GLOBAL[ctorName] === 'function' && val instanceof GLOBAL[ctorName])
-                    return true;
-            }
-
-            return false;
+            return Object.keys(TYPED_ARRAY_CTORS).some(function (ctorName) {
+                return TYPED_ARRAY_SUPPORTED(ctorName) && val instanceof TYPED_ARRAY_CTORS[ctorName];
+            });
         },
 
         toSerializable: function (arr) {
@@ -448,7 +465,7 @@ var builtInTransforms = [
         },
 
         fromSerializable: function (val) {
-            return typeof GLOBAL[val.ctorName] === 'function' ? new GLOBAL[val.ctorName](val.arr) : val.arr;
+            return TYPED_ARRAY_SUPPORTED(val.ctorName) ? new TYPED_ARRAY_CTORS[val.ctorName](val.arr) : val.arr;
         }
     },
 

--- a/index.js
+++ b/index.js
@@ -4,10 +4,27 @@ var CIRCULAR_REF_KEY        = '@r';
 var KEY_REQUIRE_ESCAPING_RE = /^#*@(t|r)$/;
 
 var GLOBAL = (function getGlobal () {
-    // NOTE: see http://www.ecma-international.org/ecma-262/6.0/index.html#sec-performeval step 10
-    var savedEval = eval;
+    // Credits to Kithraya from https://stackoverflow.com/a/64780899
+    if (typeof window !== 'undefined' && window && window.window === window) {
+        // All browsers
+        return window;
+    } else { // webworkers, or server-side Javascript, like Node.js
+        try {
+            Object.defineProperty( Object.prototype, '__magic__', {
+                get: function() {
+                    return this;
+                },
+                configurable: true // This makes it possible to 'delete' the getter later
+            });
+            __magic__.globalThis = __magic__;
+            delete Object.prototype.__magic__;
 
-    return savedEval('this');
+            return globalThis;
+        } catch (e) {
+            // we shouldn't ever get here, since all server-side JS environments that I know of support Object.defineProperty
+            return (typeof globalThis === 'object') ? globalThis : ( (typeof global === 'object') ? global : this );
+        }
+    }
 })();
 
 var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var CIRCULAR_REF_KEY        = '@r';
 var KEY_REQUIRE_ESCAPING_RE = /^#*@(t|r)$/;
 
 var GLOBAL = (function getGlobal () {
+    /* eslint-disable */
     // Credits to Kithraya from https://stackoverflow.com/a/64780899
     if (typeof window !== 'undefined' && window && window.window === window) {
         // All browsers
@@ -25,7 +26,9 @@ var GLOBAL = (function getGlobal () {
             return (typeof globalThis === 'object') ? globalThis : ( (typeof global === 'object') ? global : this );
         }
     }
+    /* eslint-enable */
 })();
+
 
 var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';
 var MAP_SUPPORTED          = typeof Map === 'function';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replicator",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Advanced JavaScript objects serialization.",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/inikulin/replicator#readme",
   "devDependencies": {
     "eslint": "^2.9.0",
-    "mocha": "^5.2.0",
+    "mocha": "^8.4.0",
     "publish-please": "^5.4.3"
   }
 }

--- a/test/helpers/gh-16.js
+++ b/test/helpers/gh-16.js
@@ -1,0 +1,46 @@
+const TICK_COUNT = 3;
+
+function evilFunction () {
+    global.evilFlag = true;
+}
+
+function makeIIFE (code) {
+    return `(${code})()`;
+}
+
+function waitTick () {
+    return new Promise(resolve => setTimeout(resolve));
+} 
+
+function waitSomeTicks (tickCount) {
+    let chain = Promise.resolve();
+
+    for (let i = 0; i < tickCount; i++)
+        chain = chain.then(waitTick);
+
+    return chain;
+} 
+
+module.exports.vulnerableData = JSON.stringify([{
+    '@t': '[[TypedArray]]',
+
+    'data': {
+        'ctorName': 'setTimeout',
+        
+        'arr': {
+            '@t': '[[TypedArray]]',
+            
+            'data': {
+                'ctorName': 'Function',
+                'arr':      makeIIFE(evilFunction.toString())
+            }
+        }
+    }
+}]);
+
+module.exports.checkIfBroken = function () {
+    return waitSomeTicks(TICK_COUNT)
+        .then(function () {
+            return !!global.evilFlag;
+        });
+};


### PR DESCRIPTION
At the moment Replicator is breaking javascript bundles in environments where a strict Content Security Policy prevents use of `eval()`.

The following changes fix that issue by using another method for retrieving the global object.