### PR TITLE
fix: Avoid RCE when deserialising TypedArrays [closes #16][part of #12]

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,22 +10,25 @@ var GLOBAL = (function getGlobal () {
     return savedEval('this');
 })();
 
+var TYPED_ARRAY_CTORS = {
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array
+};
+
 var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';
 var MAP_SUPPORTED          = typeof Map === 'function';
 var SET_SUPPORTED          = typeof Set === 'function';
 
-var TYPED_ARRAY_CTORS = [
-    'Int8Array',
-    'Uint8Array',
-    'Uint8ClampedArray',
-    'Int16Array',
-    'Uint16Array',
-    'Int32Array',
-    'Uint32Array',
-    'Float32Array',
-    'Float64Array'
-];
-
+var TYPED_ARRAY_SUPPORTED  = function (typeName) {
+    return typeof TYPED_ARRAY_CTORS[typeName] === 'function'; 
+}
 
 // Saved proto functions
 var arrSlice = Array.prototype.slice;
@@ -410,14 +413,9 @@ var builtInTransforms = [
         type: '[[TypedArray]]',
 
         shouldTransform: function (type, val) {
-            for (var i = 0; i < TYPED_ARRAY_CTORS.length; i++) {
-                var ctorName = TYPED_ARRAY_CTORS[i];
-
-                if (typeof GLOBAL[ctorName] === 'function' && val instanceof GLOBAL[ctorName])
-                    return true;
-            }
-
-            return false;
+            return Object.keys(TYPED_ARRAY_CTORS).some(function (ctorName) {
+                return TYPED_ARRAY_SUPPORTED(ctorName) && val instanceof TYPED_ARRAY_CTORS[ctorName];
+            });
         },
 
         toSerializable: function (arr) {
@@ -428,7 +426,7 @@ var builtInTransforms = [
         },
 
         fromSerializable: function (val) {
-            return typeof GLOBAL[val.ctorName] === 'function' ? new GLOBAL[val.ctorName](val.arr) : val.arr;
+            return TYPED_ARRAY_SUPPORTED(val.ctorName) ? new TYPED_ARRAY_CTORS[val.ctorName](val.arr) : val.arr;
         }
     },
 

--- a/index.js
+++ b/index.js
@@ -11,15 +11,15 @@ var GLOBAL = (function getGlobal () {
 })();
 
 var TYPED_ARRAY_CTORS = {
-    Int8Array,
-    Uint8Array,
-    Uint8ClampedArray,
-    Int16Array,
-    Uint16Array,
-    Int32Array,
-    Uint32Array,
-    Float32Array,
-    Float64Array
+    'Int8Array': Int8Array,
+    'Uint8Array': Uint8Array,
+    'Uint8ClampedArray': Uint8ClampedArray,
+    'Int16Array': Int16Array,
+    'Uint16Array': Uint16Array,
+    'Int32Array': Int32Array,
+    'Uint32Array': Uint32Array,
+    'Float32Array': Float32Array,
+    'Float64Array': Float64Array
 };
 
 function isFunction (value) {

--- a/index.js
+++ b/index.js
@@ -11,15 +11,15 @@ var GLOBAL = (function getGlobal () {
 })();
 
 var TYPED_ARRAY_CTORS = {
-    'Int8Array': Int8Array,
-    'Uint8Array': Uint8Array,
+    'Int8Array':         Int8Array,
+    'Uint8Array':        Uint8Array,
     'Uint8ClampedArray': Uint8ClampedArray,
-    'Int16Array': Int16Array,
-    'Uint16Array': Uint16Array,
-    'Int32Array': Int32Array,
-    'Uint32Array': Uint32Array,
-    'Float32Array': Float32Array,
-    'Float64Array': Float64Array
+    'Int16Array':        Int16Array,
+    'Uint16Array':       Uint16Array,
+    'Int32Array':        Int32Array,
+    'Uint32Array':       Uint32Array,
+    'Float32Array':      Float32Array,
+    'Float64Array':      Float64Array
 };
 
 function isFunction (value) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var SET_SUPPORTED          = typeof Set === 'function';
 
 var TYPED_ARRAY_SUPPORTED  = function (typeName) {
     return typeof TYPED_ARRAY_CTORS[typeName] === 'function'; 
-}
+};
 
 // Saved proto functions
 var arrSlice = Array.prototype.slice;

--- a/index.js
+++ b/index.js
@@ -22,12 +22,16 @@ var TYPED_ARRAY_CTORS = {
     Float64Array
 };
 
-var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';
-var MAP_SUPPORTED          = typeof Map === 'function';
-var SET_SUPPORTED          = typeof Set === 'function';
+function isFunction (value) {
+    return typeof value === 'function';
+}
+
+var ARRAY_BUFFER_SUPPORTED = isFunction(ArrayBuffer);
+var MAP_SUPPORTED          = isFunction(Map);
+var SET_SUPPORTED          = isFunction(Set);
 
 var TYPED_ARRAY_SUPPORTED  = function (typeName) {
-    return typeof TYPED_ARRAY_CTORS[typeName] === 'function'; 
+    return isFunction(TYPED_ARRAY_CTORS[typeName]); 
 };
 
 // Saved proto functions

--- a/test/helpers/gh-16.js
+++ b/test/helpers/gh-16.js
@@ -1,0 +1,46 @@
+const TICK_COUNT = 3;
+
+function evilFunction () {
+    global.evilFlag = true;
+}
+
+function makeIIFE (code) {
+    return `(${code})()`;
+}
+
+function waitTick () {
+    return new Promise(resolve => setTimeout(resolve));
+} 
+
+function waitSomeTicks (tickCount) {
+    let chain = Promise.resolve();
+
+    for (let i = 0; i < tickCount; i++)
+        chain = chain.then(waitTick);
+
+    return chain;
+} 
+
+module.exports.vulnerableData = JSON.stringify([{
+    '@t': '[[TypedArray]]',
+
+    'data': {
+        'ctorName': 'setTimeout',
+        
+        'arr': {
+            '@t': '[[TypedArray]]',
+            
+            'data': {
+                'ctorName': 'Function',
+                'arr':      makeIIFE(evilFunction.toString())
+            }
+        }
+    }
+}]);
+
+module.exports.checkIfBroken = function () {
+    return waitSomeTicks(TICK_COUNT)
+        .then(function () {
+            return !!global.evilFlag;
+        });
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,7 @@
-var Replicator = require('../');
-var assert     = require('assert');
+const Replicator  = require('../');
+const assert      = require('assert');
+const helpersGH16 = require('./helpers/gh-16');
+
 
 it('Should add and remove transforms', function () {
     var replicator = new Replicator();
@@ -406,5 +408,14 @@ describe('Regression', function () {
         
         assert.strictEqual(actual.foo, 'bar');
         assert.strictEqual(actual.ans, 42);
+    });
+
+    it('Should not allow RCE when deserializing TypedArrays', function () {
+        replicator.decode(helpersGH16.vulnerableData); 
+
+        return helpersGH16.checkIfBroken()
+            .then(function (result) {
+                assert.strictEqual(result, false);
+            });
     });
 });


### PR DESCRIPTION
[closes #16][part of #12]

Added a check for the array constructor at the deserialization step.

Tools and modern language features, as well as additional security measures, will come in future PRs (check my plans in #12, #13, #14, #15)