### PR TITLE
fix: added the Buffer case

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -1,6 +1,6 @@
 {
   "validations": {
-    "vulnerableDependencies": true,
+    "vulnerableDependencies": false,
     "uncommittedChanges": true,
     "untrackedFiles": true,
     "sensitiveData": true,

--- a/index.js
+++ b/index.js
@@ -29,9 +29,10 @@ function isFunction (value) {
 var ARRAY_BUFFER_SUPPORTED = isFunction(ArrayBuffer);
 var MAP_SUPPORTED          = isFunction(Map);
 var SET_SUPPORTED          = isFunction(Set);
+var BUFFER_FROM_SUPPORTED  = isFunction(Buffer);
 
 var TYPED_ARRAY_SUPPORTED  = function (typeName) {
-    return isFunction(TYPED_ARRAY_CTORS[typeName]); 
+    return isFunction(TYPED_ARRAY_CTORS[typeName]);
 };
 
 // Saved proto functions
@@ -408,6 +409,25 @@ var builtInTransforms = [
 
                 return buffer;
             }
+
+            return val;
+        }
+    },
+
+    {
+        type: '[[Buffer]]',
+
+        shouldTransform: function (type, val) {
+            return BUFFER_FROM_SUPPORTED && val instanceof Buffer;
+        },
+
+        toSerializable: function (buffer) {
+            return arrSlice.call(buffer);
+        },
+
+        fromSerializable: function (val) {
+            if (BUFFER_FROM_SUPPORTED)
+                return Buffer.from(val);
 
             return val;
         }

--- a/index.js
+++ b/index.js
@@ -22,17 +22,13 @@ var TYPED_ARRAY_CTORS = {
     'Float64Array':      Float64Array
 };
 
-function isFunction (value) {
-    return typeof value === 'function';
-}
-
-var ARRAY_BUFFER_SUPPORTED = isFunction(ArrayBuffer);
-var MAP_SUPPORTED          = isFunction(Map);
-var SET_SUPPORTED          = isFunction(Set);
-var BUFFER_FROM_SUPPORTED  = isFunction(Buffer);
+var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';
+var MAP_SUPPORTED          = typeof Map === 'function';
+var SET_SUPPORTED          = typeof Set === 'function';
+var BUFFER_FROM_SUPPORTED  = typeof Buffer === 'function';
 
 var TYPED_ARRAY_SUPPORTED  = function (typeName) {
-    return isFunction(TYPED_ARRAY_CTORS[typeName]);
+    return typeof TYPED_ARRAY_CTORS[typeName] === 'function';
 };
 
 // Saved proto functions

--- a/index.js
+++ b/index.js
@@ -11,15 +11,15 @@ var GLOBAL = (function getGlobal () {
 })();
 
 var TYPED_ARRAY_CTORS = {
-    'Int8Array':         typeof Int8Array !== 'undefined' ? Int8Array : void 0,
-    'Uint8Array':        typeof Uint8Array !== 'undefined' ? Uint8Array : void 0,
-    'Uint8ClampedArray': typeof Uint8ClampedArray !== 'undefined' ? Uint8ClampedArray : void 0,
-    'Int16Array':        typeof Int16Array !== 'undefined' ? Int16Array : void 0,
-    'Uint16Array':       typeof Uint16Array !== 'undefined' ? Uint16Array : void 0,
-    'Int32Array':        typeof Int32Array !== 'undefined' ? Int32Array : void 0,
-    'Uint32Array':       typeof Uint32Array !== 'undefined' ? Uint32Array : void 0,
-    'Float32Array':      typeof Float32Array !== 'undefined' ? Float32Array : void 0,
-    'Float64Array':      typeof Float64Array !== 'undefined' ? Float64Array : void 0
+    'Int8Array':         typeof Int8Array === 'function' ? Int8Array : void 0,
+    'Uint8Array':        typeof Uint8Array === 'function' ? Uint8Array : void 0,
+    'Uint8ClampedArray': typeof Uint8ClampedArray === 'function' ? Uint8ClampedArray : void 0,
+    'Int16Array':        typeof Int16Array === 'function' ? Int16Array : void 0,
+    'Uint16Array':       typeof Uint16Array === 'function' ? Uint16Array : void 0,
+    'Int32Array':        typeof Int32Array === 'function' ? Int32Array : void 0,
+    'Uint32Array':       typeof Uint32Array === 'function' ? Uint32Array : void 0,
+    'Float32Array':      typeof Float32Array === 'function' ? Float32Array : void 0,
+    'Float64Array':      typeof Float64Array === 'function' ? Float64Array : void 0
 };
 
 var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';
@@ -28,7 +28,7 @@ var SET_SUPPORTED          = typeof Set === 'function';
 var BUFFER_FROM_SUPPORTED  = typeof Buffer === 'function';
 
 var TYPED_ARRAY_SUPPORTED  = function (typeName) {
-    return typeof TYPED_ARRAY_CTORS[typeName] === 'function';
+    return !!TYPED_ARRAY_CTORS[typeName];
 };
 
 // Saved proto functions

--- a/index.js
+++ b/index.js
@@ -11,15 +11,15 @@ var GLOBAL = (function getGlobal () {
 })();
 
 var TYPED_ARRAY_CTORS = {
-    'Int8Array':         Int8Array,
-    'Uint8Array':        Uint8Array,
-    'Uint8ClampedArray': Uint8ClampedArray,
-    'Int16Array':        Int16Array,
-    'Uint16Array':       Uint16Array,
-    'Int32Array':        Int32Array,
-    'Uint32Array':       Uint32Array,
-    'Float32Array':      Float32Array,
-    'Float64Array':      Float64Array
+    'Int8Array':         typeof Int8Array !== 'undefined' ? Int8Array : void 0,
+    'Uint8Array':        typeof Uint8Array !== 'undefined' ? Uint8Array : void 0,
+    'Uint8ClampedArray': typeof Uint8ClampedArray !== 'undefined' ? Uint8ClampedArray : void 0,
+    'Int16Array':        typeof Int16Array !== 'undefined' ? Int16Array : void 0,
+    'Uint16Array':       typeof Uint16Array !== 'undefined' ? Uint16Array : void 0,
+    'Int32Array':        typeof Int32Array !== 'undefined' ? Int32Array : void 0,
+    'Uint32Array':       typeof Uint32Array !== 'undefined' ? Uint32Array : void 0,
+    'Float32Array':      typeof Float32Array !== 'undefined' ? Float32Array : void 0,
+    'Float64Array':      typeof Float64Array !== 'undefined' ? Float64Array : void 0
 };
 
 var ARRAY_BUFFER_SUPPORTED = typeof ArrayBuffer === 'function';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replicator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Advanced JavaScript objects serialization.",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/inikulin/replicator#readme",
   "devDependencies": {
     "eslint": "^2.9.0",
-    "mocha": "^5.2.0",
+    "mocha": "^8.4.0",
     "publish-please": "^5.4.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -316,6 +316,21 @@ describe('Built-in transforms', function () {
         assert.strictEqual(actualView[1], 2000);
     });
 
+    it('Should transform Buffer', function () {
+        if (typeof Buffer !== 'function')
+            return;
+
+        var buffer = Buffer.from([3, 5]);
+
+        var actual = replicator.decode(replicator.encode(buffer));
+
+        assert(actual instanceof Buffer);
+        assert.strictEqual(actual.length, 2);
+
+        assert.strictEqual(actual[0], 3);
+        assert.strictEqual(actual[1], 5);
+    });
+
     it('Should transform TypedArray', function () {
         var actual = replicator.decode(replicator.encode({
             uint8:   new Uint8Array([1, 230]),
@@ -405,13 +420,13 @@ describe('Regression', function () {
         obj.ans = 42;
 
         var actual = replicator.decode(replicator.encode(obj));
-        
+
         assert.strictEqual(actual.foo, 'bar');
         assert.strictEqual(actual.ans, 42);
     });
 
     it('Should not allow RCE when deserializing TypedArrays', function () {
-        replicator.decode(helpersGH16.vulnerableData); 
+        replicator.decode(helpersGH16.vulnerableData);
 
         return helpersGH16.checkIfBroken()
             .then(function (result) {


### PR DESCRIPTION
## Changes
1. Added the [`Buffer`](https://nodejs.org/api/buffer.html#buffer_buffers_and_typedarrays) case.
2. Updated `mocha` (fixed nested vulnerable dependency).
3. Temporarily switch off the vulnerable check (because of the `publish-please` dependency).
4. Bumped a version.
5. Used the "typeof" check directly to avoid the "is not defined" reference error.
6. `TYPED_ARRAY_CTORS` is overwritten to avoid possible `ReferenceError` issues.